### PR TITLE
HashSet/HashMap now use CompiledNames for C# interop

### DIFF
--- a/src/CSharp.Data.Adaptive/HashMap.fs
+++ b/src/CSharp.Data.Adaptive/HashMap.fs
@@ -4,6 +4,7 @@ open System
 open System.Runtime.CompilerServices
 open FSharp.Data.Adaptive
 
+[<CompiledName("FSharpHashMapBuilder")>]
 type HashMapBuilder<'Key, 'Value>() =
     let mutable array : struct('Key * 'Value)[] = Array.zeroCreate 8
     let mutable cnt = 0
@@ -16,10 +17,11 @@ type HashMapBuilder<'Key, 'Value>() =
     interface System.Collections.IEnumerable with
         member x.GetEnumerator() = (Seq.take cnt array).GetEnumerator() :> _
 
+    [<CompiledName("ToFSharpHashMap")>]
     member x.ToHashMap() =
         HashMap<'Key, 'Value>.OfArrayRangeV(array, 0, cnt)
    
-[<AbstractClass; Sealed; Extension>]
+[<AbstractClass; Sealed; Extension; CompiledName("FSharpHashMap")>]
 type HashMap private() =
     [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
     static member Empty<'K, 'V>() = HashMap.empty<'K, 'V>
@@ -27,22 +29,22 @@ type HashMap private() =
     [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
     static member Single<'K, 'V>(k : 'K, v : 'V) = HashMap.single k v
 
-    [<Extension; MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    [<Extension; MethodImpl(MethodImplOptions.AggressiveInlining); CompiledName("ToFSharpHashMap")>]
     static member ToHashMap(this: seq<'K * 'V>) = HashMap.ofSeq this
 
-    [<Extension; MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    [<Extension; MethodImpl(MethodImplOptions.AggressiveInlining); CompiledName("ToFSharpHashMap")>]
     static member ToHashMap(this: list<'K * 'V>) = HashMap.ofList this
 
-    [<Extension; MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    [<Extension; MethodImpl(MethodImplOptions.AggressiveInlining); CompiledName("ToFSharpHashMap")>]
     static member ToHashMap(this: ('K * 'V)[]) = HashMap.ofArray this
 
-    [<Extension; MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    [<Extension; MethodImpl(MethodImplOptions.AggressiveInlining); CompiledName("ToFSharpHashMap")>]
     static member ToHashMap(this: seq<struct ('K * 'V)>) = HashMap.OfSeqV this
 
-    [<Extension; MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    [<Extension; MethodImpl(MethodImplOptions.AggressiveInlining); CompiledName("ToFSharpHashMap")>]
     static member ToHashMap(this: list<struct ('K * 'V)>) = HashMap.OfSeqV this
 
-    [<Extension; MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    [<Extension; MethodImpl(MethodImplOptions.AggressiveInlining); CompiledName("ToFSharpHashMap")>]
     static member ToHashMap(this: struct('K * 'V)[]) = HashMap.OfSeqV this
     
     [<Extension; MethodImpl(MethodImplOptions.AggressiveInlining)>]

--- a/src/CSharp.Data.Adaptive/HashMap.fs
+++ b/src/CSharp.Data.Adaptive/HashMap.fs
@@ -4,7 +4,7 @@ open System
 open System.Runtime.CompilerServices
 open FSharp.Data.Adaptive
 
-[<CompiledName("FSharpHashMapBuilder")>]
+[<CompiledName("FSharpHashMapBuilder`2")>]
 type HashMapBuilder<'Key, 'Value>() =
     let mutable array : struct('Key * 'Value)[] = Array.zeroCreate 8
     let mutable cnt = 0

--- a/src/CSharp.Data.Adaptive/HashSet.fs
+++ b/src/CSharp.Data.Adaptive/HashSet.fs
@@ -4,6 +4,7 @@ open System
 open System.Runtime.CompilerServices
 open FSharp.Data.Adaptive
 
+[<CompiledName("FSharpHashSetBuilder")>]
 type HashSetBuilder<'T>() =
     let mutable array : 'T[] = Array.zeroCreate 8
     let mutable cnt = 0
@@ -16,10 +17,11 @@ type HashSetBuilder<'T>() =
     interface System.Collections.IEnumerable with
         member x.GetEnumerator() = (Seq.take cnt array).GetEnumerator() :> _
 
+    [<CompiledName("ToFSharpHashSet")>]
     member x.ToHashSet() =
         HashSet<'T>.OfArrayRange(array, 0, cnt)
 
-[<AbstractClass; Sealed; Extension>]
+[<AbstractClass; Sealed; Extension; CompiledName("FSharpHashSet")>]
 type HashSet private() =
     
     [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
@@ -32,13 +34,13 @@ type HashSet private() =
     [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
     static member Single<'T>(value: 'T) = HashSet.single value
     
-    [<Extension; MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    [<Extension; MethodImpl(MethodImplOptions.AggressiveInlining); CompiledName("ToFSharpHashSet")>]
     static member ToHashSet(elements: seq<'T>) = HashSet.ofSeq elements
     
-    [<Extension; MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    [<Extension; MethodImpl(MethodImplOptions.AggressiveInlining); CompiledName("ToFSharpHashSet")>]
     static member ToHashSet(elements: list<'T>) = HashSet.ofList elements
     
-    [<Extension; MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    [<Extension; MethodImpl(MethodImplOptions.AggressiveInlining); CompiledName("ToFSharpHashSet")>]
     static member ToHashSet(elements: 'T[]) = HashSet.ofArray elements
     
     [<Extension; MethodImpl(MethodImplOptions.AggressiveInlining)>]
@@ -111,7 +113,7 @@ type HashSet private() =
         let (a,b) = HashSet.applyDelta set delta
         struct(a,b)
      
-[<AbstractClass; Sealed; Extension>]
+[<AbstractClass; Sealed; Extension; CompiledName("FSharpHashSetDelta")>]
 type HashSetDelta private() =
     
     [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
@@ -124,13 +126,13 @@ type HashSetDelta private() =
     [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
     static member Single<'T>(value: SetOperation<'T>) = HashSetDelta.single value
     
-    [<Extension; MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    [<Extension; MethodImpl(MethodImplOptions.AggressiveInlining); CompiledName("ToFSharpHashSetDelta")>]
     static member ToHashSetDelta(elements: seq<SetOperation<'T>>) = HashSetDelta.ofSeq elements
     
-    [<Extension; MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    [<Extension; MethodImpl(MethodImplOptions.AggressiveInlining); CompiledName("ToFSharpHashSetDelta")>]
     static member ToHashSetDelta(elements: list<SetOperation<'T>>) = HashSetDelta.ofList elements
     
-    [<Extension; MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    [<Extension; MethodImpl(MethodImplOptions.AggressiveInlining); CompiledName("ToFSharpHashSetDelta")>]
     static member ToHashSetDelta(elements: SetOperation<'T>[]) = HashSetDelta.ofArray elements
     
     [<Extension; MethodImpl(MethodImplOptions.AggressiveInlining)>]

--- a/src/CSharp.Data.Adaptive/HashSet.fs
+++ b/src/CSharp.Data.Adaptive/HashSet.fs
@@ -4,7 +4,7 @@ open System
 open System.Runtime.CompilerServices
 open FSharp.Data.Adaptive
 
-[<CompiledName("FSharpHashSetBuilder")>]
+[<CompiledName("FSharpHashSetBuilder`1")>]
 type HashSetBuilder<'T>() =
     let mutable array : 'T[] = Array.zeroCreate 8
     let mutable cnt = 0

--- a/src/Demo/CSharpInterop/Program.cs
+++ b/src/Demo/CSharpInterop/Program.cs
@@ -14,9 +14,11 @@ namespace CSharpInterop
         {
             DefaultEqualityComparer.SetProvider(DefaultEqualityComparer.System);
 
+            var testSet = new FSharpHashSet<int>(new [] { 1, 2, 3, 4 });
+
             var mappy =
-                new HashMapBuilder<int, int> { { 1, 3 }, { 2, 4 } }
-                .ToHashMap()
+                new FSharpHashMapBuilder<int, int> { { 1, 3 }, { 2, 4 } }
+                .ToFSharpHashMap()
                 .Add(4, 5)
                 .Remove(2)
                 .Alter(1, (int? o) => o)
@@ -24,23 +26,23 @@ namespace CSharpInterop
                 .Alter(1, o => o)
                 .Map((k, v) => v * 3);
 
-            var delta123123 = mappy.ComputeDeltaTo(HashMap.Empty<int, int>());
+            var delta123123 = mappy.ComputeDeltaTo(FSharpHashMap.Empty<int, int>());
 
             var (sm, dm) = mappy.ApplyDelta(delta123123);
 
-            var smasdasd = HashMap.Empty<int, int>().ApplyDelta(ref delta123123);
+            var smasdasd = FSharpHashMap.Empty<int, int>().ApplyDelta(ref delta123123);
 
-            var test =
+            FSharpHashSet<int> test =
                 new[] { 1, 2, 3, 4, 5 }
-                .ToHashSet()
+                .ToFSharpHashSet()
                 .Map(i => i * 2)
                 .Filter(i => i % 2 == 0)
-                .Collect(i => HashSet.Single(i))
-                .Subtract(HashSet.Single(2))
+                .Collect(i => FSharpHashSet.Single(i))
+                .Subtract(FSharpHashSet.Single(2))
                 .Alter(2, i => !i)
                 .MapNullable(i => i < 10 ? (int?)i : null);
 
-            var delta = test.ComputeDeltaTo(HashSet.Empty<int>()).Add(SetOperation<int>.Add(2131));
+            var delta = test.ComputeDeltaTo(FSharpHashSet.Empty<int>()).Add(SetOperation<int>.Add(2131));
             var sepp1 = test.ApplyDelta(ref delta);
             var (newState, realDelta) = test.ApplyDelta(delta);
 
@@ -66,7 +68,7 @@ namespace CSharpInterop
             Console.WriteLine("{0}", dependent.GetValue());
             using (Adaptive.Transact)
             {
-                changeableSet.Value = new HashSetBuilder<int>() { 5, 6, 7, 8, 9, 0 }.ToHashSet();
+                changeableSet.Value = new FSharpHashSetBuilder<int>() { 5, 6, 7, 8, 9, 0 }.ToFSharpHashSet();
                 changeableMap.Value = HashMapModule.empty<int, int>();
                 changeableList.Value = IndexListModule.empty<int>();
                 changeableList.Add(1);

--- a/src/FSharp.Data.Adaptive/Datastructures/HashCollections.fs
+++ b/src/FSharp.Data.Adaptive/Datastructures/HashCollections.fs
@@ -3955,17 +3955,19 @@ type HashMap<'K, [<EqualityConditionalOn>] 'V> internal(cmp: IEqualityComparer<'
         member x.GetEnumerator() = new HashMapEnumerator<_,_>(root) :> _
         
         
-    new(elements : HashMap<'K, 'V>) = 
-        HashMap<'K, 'V>(elements.Comparer, elements.Root)
         
     new(elements : seq<'K * 'V>) = 
         let o = HashMap.OfSeq elements
         HashMap<'K, 'V>(o.Comparer, o.Root)
 
+    new(elements : HashMap<'K, 'V>) = 
+        HashMap<'K, 'V>(elements.Comparer, elements.Root)
+
     new(elements : array<'K * 'V>) = 
         let o = HashMap.OfArray elements
         HashMap<'K, 'V>(o.Comparer, o.Root)  
         
+    #if !FABLE_COMPILER
     new(elements : seq<struct ('K * 'V)>) = 
         let o = HashMap.OfSeqV elements
         HashMap<'K, 'V>(o.Comparer, o.Root)
@@ -3973,6 +3975,7 @@ type HashMap<'K, [<EqualityConditionalOn>] 'V> internal(cmp: IEqualityComparer<'
     new(elements : array<struct ('K * 'V)>) = 
         let o = HashMap.OfArrayV elements
         HashMap<'K, 'V>(o.Comparer, o.Root)
+    #endif
 
 and internal HashMapEnumerator<'K, 'V>(root: HashMapNode<'K, 'V>) =
     let mutable stack = [root]

--- a/src/FSharp.Data.Adaptive/Datastructures/HashCollections.fs
+++ b/src/FSharp.Data.Adaptive/Datastructures/HashCollections.fs
@@ -3357,7 +3357,7 @@ module internal HashMapImplementation =
 
 
 
-[<Struct; CustomEquality; NoComparison; StructuredFormatDisplay("{AsString}")>]
+[<Struct; CustomEquality; NoComparison; StructuredFormatDisplay("{AsString}"); CompiledName("FSharpHashSet`1")>]
 type HashSet<'T> internal(cmp: IEqualityComparer<'T>, root: HashSetNode<'T>) =
     
     static member Empty = HashSet<'T>(DefaultEqualityComparer<'T>.Instance, HashSetEmpty.Instance)
@@ -3365,6 +3365,7 @@ type HashSet<'T> internal(cmp: IEqualityComparer<'T>, root: HashSetNode<'T>) =
     member x.Count = root.Count
     member x.IsEmpty = root.IsEmpty
 
+    member internal x.Comparer = cmp
     member internal x.Root = root
     
     member private x.AsString = x.ToString()
@@ -3584,6 +3585,18 @@ type HashSet<'T> internal(cmp: IEqualityComparer<'T>, root: HashSetNode<'T>) =
     interface System.Collections.Generic.IEnumerable<'T> with 
         member x.GetEnumerator() = new HashSetEnumerator<_>(root) :> _
 
+    new(elements : seq<'T>) = 
+        let o = HashSet.OfSeq elements
+        HashSet<'T>(o.Comparer, o.Root)
+        
+    new(elements : HashSet<'T>) = 
+        HashSet<'T>(elements.Comparer, elements.Root)
+        
+    new(elements : 'T[]) = 
+        let o = HashSet.OfArray elements
+        HashSet<'T>(o.Comparer, o.Root)
+        
+
 and internal HashSetEnumerator<'T>(root: HashSetNode<'T>) =
     let mutable stack = [root]
     let mutable linked: HashSetLinked<'T> = null
@@ -3636,7 +3649,7 @@ and internal HashSetEnumerator<'T>(root: HashSetNode<'T>) =
         member x.Current = x.Current
 
 
-[<Struct; CustomEquality; NoComparison; StructuredFormatDisplay("{AsString}")>]
+[<Struct; CustomEquality; NoComparison; StructuredFormatDisplay("{AsString}"); CompiledName("FSharpHashMap`2")>]
 type HashMap<'K, [<EqualityConditionalOn>] 'V> internal(cmp: IEqualityComparer<'K>, root: HashMapNode<'K, 'V>) =
 
     static member Empty = HashMap<'K, 'V>(DefaultEqualityComparer<'K>.Instance, HashMapEmpty.Instance)
@@ -3644,6 +3657,7 @@ type HashMap<'K, [<EqualityConditionalOn>] 'V> internal(cmp: IEqualityComparer<'
     member x.Count = root.Count
     member x.IsEmpty = root.IsEmpty
 
+    member internal x.Comparer = cmp
     member internal x.Root : HashMapNode<'K, 'V> = root
     
     member x.Item
@@ -3939,6 +3953,26 @@ type HashMap<'K, [<EqualityConditionalOn>] 'V> internal(cmp: IEqualityComparer<'
         
     interface System.Collections.Generic.IEnumerable<'K * 'V> with 
         member x.GetEnumerator() = new HashMapEnumerator<_,_>(root) :> _
+        
+        
+    new(elements : HashMap<'K, 'V>) = 
+        HashMap<'K, 'V>(elements.Comparer, elements.Root)
+        
+    new(elements : seq<'K * 'V>) = 
+        let o = HashMap.OfSeq elements
+        HashMap<'K, 'V>(o.Comparer, o.Root)
+
+    new(elements : array<'K * 'V>) = 
+        let o = HashMap.OfArray elements
+        HashMap<'K, 'V>(o.Comparer, o.Root)  
+        
+    new(elements : seq<struct ('K * 'V)>) = 
+        let o = HashMap.OfSeqV elements
+        HashMap<'K, 'V>(o.Comparer, o.Root)
+
+    new(elements : array<struct ('K * 'V)>) = 
+        let o = HashMap.OfArrayV elements
+        HashMap<'K, 'V>(o.Comparer, o.Root)
 
 and internal HashMapEnumerator<'K, 'V>(root: HashMapNode<'K, 'V>) =
     let mutable stack = [root]
@@ -4042,7 +4076,9 @@ and internal HashMapStructEnumerator<'K, 'V>(root: HashMapNode<'K, 'V>) =
         member x.Dispose() = x.Dispose()
         member x.Current = x.Current
 
+
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+[<RequireQualifiedAccess>]
 module HashSet =
 
     /// The empty set.
@@ -4200,6 +4236,7 @@ module HashSet =
         HashSet<'T>.ApplyDelta(l, r, apply)
 
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+[<RequireQualifiedAccess>]
 module HashMap =
 
     /// The empty map.

--- a/src/FSharp.Data.Adaptive/Datastructures/HashMapDelta.fs
+++ b/src/FSharp.Data.Adaptive/Datastructures/HashMapDelta.fs
@@ -6,7 +6,7 @@ open FSharp.Data.Adaptive
 
 /// Represents the difference of two HashMaps.
 [<Struct; CustomEquality; NoComparison>]
-[<StructuredFormatDisplay("{AsString}"); CompiledName("FSharpHashMapDelta")>]
+[<StructuredFormatDisplay("{AsString}"); CompiledName("FSharpHashMapDelta`2")>]
 type HashMapDelta<'K, [<EqualityConditionalOn>] 'V>(store : HashMap<'K, ElementOperation<'V>>) =
     static let empty = HashMapDelta<'K, 'V>(HashMap.empty)
 

--- a/src/FSharp.Data.Adaptive/Datastructures/HashMapDelta.fs
+++ b/src/FSharp.Data.Adaptive/Datastructures/HashMapDelta.fs
@@ -6,7 +6,7 @@ open FSharp.Data.Adaptive
 
 /// Represents the difference of two HashMaps.
 [<Struct; CustomEquality; NoComparison>]
-[<StructuredFormatDisplay("{AsString}")>]
+[<StructuredFormatDisplay("{AsString}"); CompiledName("FSharpHashMapDelta")>]
 type HashMapDelta<'K, [<EqualityConditionalOn>] 'V>(store : HashMap<'K, ElementOperation<'V>>) =
     static let empty = HashMapDelta<'K, 'V>(HashMap.empty)
 
@@ -58,6 +58,7 @@ type HashMapDelta<'K, [<EqualityConditionalOn>] 'V>(store : HashMap<'K, ElementO
 
 
 /// Functional operators for HashMapDelta.
+[<CompiledName("FSharpHashMapDeltaModule")>]
 module HashMapDelta =
     /// The empty map delta.
     [<GeneralizableValue>]

--- a/src/FSharp.Data.Adaptive/Datastructures/HashSetDelta.fs
+++ b/src/FSharp.Data.Adaptive/Datastructures/HashSetDelta.fs
@@ -9,7 +9,7 @@ open FSharp.Data.Adaptive
 /// Internally uses reference counts to represent deltas and provides 
 /// convenient combine functions.
 [<Struct; CustomEquality; NoComparison>]
-[<StructuredFormatDisplay("{AsString}")>]
+[<StructuredFormatDisplay("{AsString}"); CompiledName("FSharpHashSetDelta")>]
 type HashSetDelta<'T>(store: HashMap<'T, int>) =
 
     /// The empty set.
@@ -202,7 +202,7 @@ and private DHashSetEnumerator<'T>(store: HashMap<'T, int>) =
         member x.Current = x.Current
 
 /// Functional operators for HashSetDelta.
-[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix); CompiledName("FSharpHashSetDeltaModule")>]
 module HashSetDelta =
 
     /// The empty set.

--- a/src/FSharp.Data.Adaptive/Datastructures/HashSetDelta.fs
+++ b/src/FSharp.Data.Adaptive/Datastructures/HashSetDelta.fs
@@ -9,7 +9,7 @@ open FSharp.Data.Adaptive
 /// Internally uses reference counts to represent deltas and provides 
 /// convenient combine functions.
 [<Struct; CustomEquality; NoComparison>]
-[<StructuredFormatDisplay("{AsString}"); CompiledName("FSharpHashSetDelta")>]
+[<StructuredFormatDisplay("{AsString}"); CompiledName("FSharpHashSetDelta`1")>]
 type HashSetDelta<'T>(store: HashMap<'T, int>) =
 
     /// The empty set.


### PR DESCRIPTION
Resolving https://github.com/fsprojects/FSharp.Data.Adaptive/issues/67

@luithefirst please review and check if all CompiledNames are consistent.