### PR TITLE
changed CurrentTransaction and RunningTransaction to ValueOption

### DIFF
--- a/src/FSharp.Data.Adaptive/AdaptiveHashMap/AdaptiveHashMap.fs
+++ b/src/FSharp.Data.Adaptive/AdaptiveHashMap/AdaptiveHashMap.fs
@@ -490,8 +490,8 @@ module AdaptiveHashMapImplementation =
                 reader <- Unchecked.defaultof<_>
             )
             match Transaction.Current with
-            | Some t -> t.Enqueue x
-            | None -> transact x.MarkOutdated
+            | ValueSome t -> t.Enqueue x
+            | ValueNone -> transact x.MarkOutdated
 
         interface System.IDisposable with
             member x.Dispose() = x.Dispose()

--- a/src/FSharp.Data.Adaptive/AdaptiveHashSet/AdaptiveHashSet.fs
+++ b/src/FSharp.Data.Adaptive/AdaptiveHashSet/AdaptiveHashSet.fs
@@ -447,8 +447,8 @@ module AdaptiveHashSetImplementation =
                 reader <- Unchecked.defaultof<_>
             )
             match Transaction.Current with
-            | Some t -> t.Enqueue x
-            | None -> transact x.MarkOutdated
+            | ValueSome t -> t.Enqueue x
+            | ValueNone -> transact x.MarkOutdated
 
         interface System.IDisposable with
             member x.Dispose() = x.Dispose()

--- a/src/FSharp.Data.Adaptive/AdaptiveIndexList/AdaptiveIndexList.fs
+++ b/src/FSharp.Data.Adaptive/AdaptiveIndexList/AdaptiveIndexList.fs
@@ -469,8 +469,8 @@ module internal AdaptiveIndexListImplementation =
                 reader <- Unchecked.defaultof<_>
             )
             match Transaction.Current with
-            | Some t -> t.Enqueue x
-            | None -> transact x.MarkOutdated
+            | ValueSome t -> t.Enqueue x
+            | ValueNone -> transact x.MarkOutdated
 
         interface System.IDisposable with
             member x.Dispose() = x.Dispose()

--- a/src/FSharp.Data.Adaptive/Core/AdaptiveObject.fs
+++ b/src/FSharp.Data.Adaptive/Core/AdaptiveObject.fs
@@ -266,8 +266,8 @@ type AdaptiveSynchronizationContext(captured : SynchronizationContext) =
         let ac = AfterEvaluateCallbacks.Callbacks
         try
             // reset all thread-locals/static to their default values
-            Transaction.Current <- None
-            Transaction.Running <- None
+            Transaction.Current <- ValueNone
+            Transaction.Running <- ValueNone
             AdaptiveObject.UnsafeEvaluationDepth <- 0
             AfterEvaluateCallbacks.Callbacks <- []
 

--- a/src/FSharp.Data.Adaptive/EvaluationCallbackExtensions.fs
+++ b/src/FSharp.Data.Adaptive/EvaluationCallbackExtensions.fs
@@ -27,8 +27,8 @@ module EvaluationCallbackExtensions =
                 )
 
             match Transaction.Running with
-            | Some t -> t.AddFinalizer (fun () -> value.GetValueUntyped AdaptiveToken.Top |> action)
-            | None -> value.GetValueUntyped AdaptiveToken.Top |> action
+            | ValueSome t -> t.AddFinalizer (fun () -> value.GetValueUntyped AdaptiveToken.Top |> action)
+            | ValueNone -> value.GetValueUntyped AdaptiveToken.Top |> action
 
             sub
             
@@ -60,8 +60,8 @@ module EvaluationCallbackExtensions =
                 )
 
             match Transaction.Running with
-            | Some t -> t.AddFinalizer (fun () -> value |> AVal.force |> action)
-            | None -> value |> AVal.force |> action
+            | ValueSome t -> t.AddFinalizer (fun () -> value |> AVal.force |> action)
+            | ValueNone -> value |> AVal.force |> action
 
             sub
             
@@ -92,8 +92,8 @@ module EvaluationCallbackExtensions =
                 )
         
             match Transaction.Running with
-            | Some t -> t.AddFinalizer run
-            | None -> run()
+            | ValueSome t -> t.AddFinalizer run
+            | ValueNone -> run()
 
             sub
             


### PR DESCRIPTION
Using `ValueOption` for `Transaction.Running` and `Transaction.Current` and thereby avoiding allocations of `FSharpOption<Transcation>`

change of public API -> might be considered for the next major version