### PR TITLE
Work around Fable's missing .isNone

### DIFF
--- a/src/FSharp.Data.Adaptive/AdaptiveHashMap/AdaptiveHashMap.fs
+++ b/src/FSharp.Data.Adaptive/AdaptiveHashMap/AdaptiveHashMap.fs
@@ -669,9 +669,9 @@ module AdaptiveHashMapImplementation =
                     | ValueSome (Remove) -> ValueNone
                     | ValueNone -> rReader.State.TryFindV key
 
-                if ValueOption.isNone lv && ValueOption.isNone rv then
-                    ValueSome Remove
-                else
+                match lv, rv with
+                | ValueNone, ValueNone -> ValueSome Remove
+                | _, _ ->
                     match mapping.Invoke(key, lv, rv) with
                     | ValueSome res -> ValueSome (Set res)
                     | ValueNone -> ValueSome Remove


### PR DESCRIPTION
When trying this code with Fable compiler, I'm getting

```Fable.Elmish.Adaptive/src/Demo/.fable/FSharp.Data.Adaptive.1.2.6/AdaptiveHashMap/AdaptiveHashMap.fs(672,19): (672,40) error FABLE: Microsoft.FSharp.Core.ValueOption.IsNone is not supported by Fable```

This is a workaround.