### PR TITLE
`mapWithAdditionalDependencies` from FSAC.

### DIFF
--- a/src/FSharp.Data.Adaptive/AdaptiveHashMap/AdaptiveHashMap.fs
+++ b/src/FSharp.Data.Adaptive/AdaptiveHashMap/AdaptiveHashMap.fs
@@ -821,7 +821,7 @@ module AdaptiveHashMapImplementation =
             let mutable changes = HashMap.empty
             let setOps =
                 (setOps, dirty)
-                ||> HashMap.fold(fun s k v -> 
+                ||> HashMap.fold(fun s k _ -> 
                     match HashMap.tryFind k old with
                     | Some v ->
                         HashMap.add k v s
@@ -1416,7 +1416,7 @@ module AMap =
             create (fun () -> MapAReader(map, mapping))
 
     /// Adaptively applies the given mapping to all changes and reapplies mapping on dirty outputs
-    let batchRecalcDirty (mapping: HashMap<'K,'T1> -> HashMap<'K,aval<'T2>>) (map: amap<'K, 'T1>) =
+    let batchRecalcDirty (mapping: HashMap<'K, 'T1> -> HashMap<'K, aval<'T2>>) (map: amap<'K, 'T1>) =
         if map.IsConstant then
             let map = force map |> mapping
             if map |> HashMap.forall (fun _ v -> v.IsConstant) then

--- a/src/FSharp.Data.Adaptive/AdaptiveHashMap/AdaptiveHashMap.fsi
+++ b/src/FSharp.Data.Adaptive/AdaptiveHashMap/AdaptiveHashMap.fsi
@@ -106,7 +106,7 @@ module AMap =
     val mapA : mapping: ('K -> 'V -> aval<'T>) -> map: amap<'K, 'V> -> amap<'K, 'T>
 
     /// Adaptively applies the given mapping to all changes.
-    val deltaA : mapping: (HashMap<'K,'T1> -> HashMap<'K,aval<'T2>>) -> map: amap<'K, 'T1> -> amap<'K, 'T2>
+    val batchRecalcDirty : mapping: (HashMap<'K,'T1> -> HashMap<'K,aval<'T2>>) -> map: amap<'K, 'T1> -> amap<'K, 'T2>
 
     /// Adaptively chooses all elements returned by mapping.  
     val chooseA : mapping: ('K -> 'V -> aval<option<'T>>) -> map: amap<'K, 'V> -> amap<'K, 'T>

--- a/src/FSharp.Data.Adaptive/AdaptiveHashMap/AdaptiveHashMap.fsi
+++ b/src/FSharp.Data.Adaptive/AdaptiveHashMap/AdaptiveHashMap.fsi
@@ -102,9 +102,11 @@ module AMap =
     /// Adaptively intersects the two maps.
     val intersectV : amap<'Key, 'Value1> -> amap<'Key, 'Value2> -> amap<'Key, struct('Value1 * 'Value2)>
 
-
     /// Adaptively applies the given mapping function to all elements and returns a new amap containing the results.
     val mapA : mapping: ('K -> 'V -> aval<'T>) -> map: amap<'K, 'V> -> amap<'K, 'T>
+
+    /// Adaptively applies the given mapping to all changes.
+    val deltaA : mapping: (HashMap<'K,'T1> -> HashMap<'K,aval<'T2>>) -> map: amap<'K, 'T1> -> amap<'K, 'T2>
 
     /// Adaptively chooses all elements returned by mapping.  
     val chooseA : mapping: ('K -> 'V -> aval<option<'T>>) -> map: amap<'K, 'V> -> amap<'K, 'T>

--- a/src/FSharp.Data.Adaptive/AdaptiveValue/AdaptiveValue.fs
+++ b/src/FSharp.Data.Adaptive/AdaptiveValue/AdaptiveValue.fs
@@ -399,6 +399,43 @@ module AVal =
                 inner <- ValueSome (struct (va, vb, vc, res))
                 res.GetValue token     
 
+
+    /// <summary>
+    /// Calls a mapping function which creates additional dependencies to be tracked.
+    /// </summary>
+    /// <remarks>
+    /// Usecase for this is when a file, such as a .fsproj file changes, it needs to be reloaded in msbuild.
+    /// Additionally fsproj files have dependencies, such as project.assets.json, that can't be determined until loaded with msbuild 
+    /// but should be reloaded if those dependent files change. 
+    /// </remarks>
+    let mapWithAdditionalDependencies (mapping: 'a -> 'b * seq<#IAdaptiveValue>) (value: aval<'a>) : aval<'b> =
+        let mutable lastDeps = HashSet.empty
+
+        { new AbstractVal<'b>() with
+            member x.Compute(token: AdaptiveToken) =
+                let input = value.GetValue token
+
+                // re-evaluate the mapping based on the (possibly new input)
+                let result, deps = mapping input
+
+                // compute the change in the additional dependencies and adjust the graph accordingly
+                let newDeps = HashSet.ofSeq deps
+
+                for op in HashSet.computeDelta lastDeps newDeps do
+                    match op with
+                    | Add(_, d) ->
+                    // the new dependency needs to be evaluated with our token, s.t. we depend on it in the future
+                        d.GetValueUntyped token |> ignore
+                    | Rem(_, d) ->
+                        // we no longer need to depend on the old dependency so we can remove ourselves from its outputs
+                        lock d.Outputs (fun () -> d.Outputs.Remove x) |> ignore
+
+                lastDeps <- newDeps
+
+                result }
+        :> aval<_>
+
+
     /// Aval for custom computations
     [<Sealed>]
     type CustomVal<'T>(compute: AdaptiveToken -> 'T) =

--- a/src/FSharp.Data.Adaptive/AdaptiveValue/AdaptiveValue.fsi
+++ b/src/FSharp.Data.Adaptive/AdaptiveValue/AdaptiveValue.fsi
@@ -108,6 +108,16 @@ module AVal =
     /// adaptive inputs.
     val map3 : mapping : ('T1 -> 'T2 -> 'T3 -> 'T4) -> value1 : aval<'T1> -> value2 : aval<'T2> -> value3 : aval<'T3> -> aval<'T4>
 
+    /// <summary>
+    /// Calls a mapping function which creates additional dependencies to be tracked.
+    /// </summary>
+    /// <remarks>
+    /// Usecase for this is when a file, such as a .fsproj file changes, it needs to be reloaded in msbuild.
+    /// Additionally fsproj files have dependencies, such as project.assets.json, that can't be determined until loaded with msbuild 
+    /// but should be reloaded if those dependent files change. 
+    /// </remarks>
+    val mapWithAdditionalDependencies : mapping :( 'T1 -> 'T2 * seq<#IAdaptiveValue>) -> value: aval<'T1> -> aval<'T2> 
+
     /// Returns a new adaptive value that adaptively applies the mapping function to the given 
     /// input and adaptively depends on the resulting adaptive value.
     /// The resulting adaptive value  will hold the latest value of the aval<_> returned by mapping.

--- a/src/Test/FSharp.Data.Adaptive.Tests/AMap.fs
+++ b/src/Test/FSharp.Data.Adaptive.Tests/AMap.fs
@@ -639,3 +639,36 @@ let ``[AMap] mapA``() =
     )
 
     res |> AMap.force |> should equal (HashMap.ofList ["A", 2; "B", 4; "C", 6])
+
+
+    
+[<Test>]
+let ``[AMap] deltaA``() =
+    let map = cmap ["A", 1; "B", 2; "C", 3]
+    let flag = cval true
+
+    let res =
+        map |> AMap.deltaA (fun d ->
+            d
+            |> HashMap.map(fun _ v -> flag |> AVal.map (function true -> v | false -> -1))
+        )
+
+    res |> AMap.force |> should equal (HashMap.ofList ["A", 1; "B", 2; "C", 3])
+
+    transact (fun () ->
+        flag.Value <- false
+    )
+
+    res |> AMap.force |> should equal (HashMap.ofList ["A", -1; "B", -1; "C", -1])
+
+    transact (fun () ->
+        map.Value <- map.Value |> HashMap.map (fun _ v -> v * 2)
+    )
+
+    res |> AMap.force |> should equal (HashMap.ofList ["A", -1; "B", -1; "C", -1])
+
+    transact (fun () ->
+        flag.Value <- true
+    )
+
+    res |> AMap.force |> should equal (HashMap.ofList ["A", 2; "B", 4; "C", 6])

--- a/src/Test/FSharp.Data.Adaptive.Tests/AVal.fs
+++ b/src/Test/FSharp.Data.Adaptive.Tests/AVal.fs
@@ -275,8 +275,6 @@ let ``[AVal] mapNonAdaptive GC correct``() =
     transact (fun () -> v.Value <- 100)
     test |> AVal.force |> should equal 101
 
-
-
 [<Test>]
 let ``[AVal] multi map non-adaptive and bind``() =
     let v = AVal.init true
@@ -289,3 +287,66 @@ let ``[AVal] multi map non-adaptive and bind``() =
 
     transact (fun () -> v.Value <- false)
     output |> AVal.force |> should equal 1
+
+
+
+[<Test>]
+let ``[AVal] mapWithAdditionalDependencies``() =
+    let v = cval 1
+    let incrDep (dep : cval<_>) =
+        dep.Value <- dep.Value + 1 
+    let mutable dependency1 = Unchecked.defaultof<_>
+    let newDep1 () =  
+        dependency1 <- cval 2
+        dependency1
+    let mutable dependency2 =  Unchecked.defaultof<_>
+    let newDep2 () = 
+        dependency2 <- cval 3
+        dependency2
+    let mutable mappingCalls = 0
+    let incrMapping () =
+        mappingCalls <- mappingCalls + 1
+
+    let mapping (i : int) =
+        incrMapping ()
+        // dependencies aren't known until mapping time
+        i * 2, [newDep1(); newDep2()]
+    
+    let output = v |> AVal.mapWithAdditionalDependencies mapping
+
+    output |> AVal.force |> should equal 2
+    mappingCalls |> should equal 1
+
+    transact (fun () -> v.Value <- 2)
+    output |> AVal.force |> should equal 4
+    mappingCalls |> should equal 2
+
+    transact (fun () -> incrDep dependency1)
+    output |> AVal.force |> should equal 4
+    mappingCalls |> should equal 3
+
+    
+    transact (fun () -> incrDep dependency1)
+    output |> AVal.force |> should equal 4
+    mappingCalls |> should equal 4
+
+    transact (fun () -> v.Value <- 2)
+    output |> AVal.force |> should equal 4
+    mappingCalls |> should equal 4
+
+    
+    transact (fun () -> v.Value <- 1)
+    output |> AVal.force |> should equal 2
+    mappingCalls |> should equal 5
+
+    transact (fun () -> 
+        v.Value <- 1
+        incrDep dependency1)
+    output |> AVal.force |> should equal 2
+    mappingCalls |> should equal 6
+
+    transact (fun () -> 
+        incrDep dependency2
+        incrDep dependency1)
+    output |> AVal.force |> should equal 2
+    mappingCalls |> should equal 7


### PR DESCRIPTION
@krauthaufen and I have been going back and forth on things that have helped the implementation of using FSharp.Data.Adaptive in [FsAutocomplete](https://github.com/fsharp/FsAutoComplete/blob/main/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs).

One of the _weird use cases_ is loading and noticing changes to `fsproj` files with msbuild. We need to re-execute retrieving msbuild project data on every change to an `fsproj` file. However there are _additional_ files that may change during editing code that isn't immediately knowable until you've already executed msbuild (such as `project.assets.json`). When those dependent files change, (due to a something such as `dotnet restore`), we also need to re-execute getting information from msbuild for that project. @krauthaufen helped craft the `AVal.mapWithAdditionalDependencies`.

The only problem with the implementation was on _any_ change we would want to reload the _whole solution_ which can take longer the more projects that are involved.  We can be a bit smarter and reload only the projects that need it.  We could do this _one at a time_ with the current offering in `AMap` but this would also be extra overhead. It would be nicer to operate in batches, so if multiple projects need reloaded, we only call out to msbuild _once_. `BatchRecalculateDirty` will rerun the mapping function for any new inputs from a `reader` _and_ any dirty ones `InputChangedObject`. 

I do have a working implementation over in https://github.com/fsharp/FsAutoComplete/pull/1082.  

---

@krauthaufen also mentioned creating implementations for `ASet` and `AList`, but I wanted to get the ball rolling on some feedback. I'm not tied to these names, if there's better ways to convey the semantics on this, I'm all ears.