### PR TITLE
#112 changed the implementation of MultiCallbackObject to address NPE

### DIFF
--- a/src/FSharp.Data.Adaptive/Core/Callbacks.fs
+++ b/src/FSharp.Data.Adaptive/Core/Callbacks.fs
@@ -36,7 +36,16 @@ type internal MultiCallbackObject(table : ConditionalWeakTable<IAdaptiveObject, 
     static let emptyOutputs = EmptyOutputSet() :> IWeakOutputSet
     let mutable level = obj.Level + 1
     
+    #if !FABLE_COMPILER
+    // we use a ConcurrentDictionary so that multiple threads can safely add and remove callbacks with out accidentally losing them
+    // since this type is NON immutable it makes sense to use a datatype here that has the behavior we want to achieve
+    // ConcurrentDictionary also has a few nice properties when used in our case here. Since we use a monotonically increasing integer
+    // new callbacks will be available to the enumerator if we have finished it yet. This is because the values are returned in key order
+    // with new keys that are greater than the current enumerator value being accessible.
+    let cbs : System.Collections.Concurrent.ConcurrentDictionary<int, WeakReference<unit -> bool>> = System.Collections.Concurrent.ConcurrentDictionary()
+    #else
     let cbs : ref<HashMap<int, WeakReference<unit -> bool>>> = ref HashMap.empty
+    #endif
     let mutable obj = obj
     let mutable weak = null
 
@@ -49,22 +58,42 @@ type internal MultiCallbackObject(table : ConditionalWeakTable<IAdaptiveObject, 
         Interlocked.Increment(&id)
         #endif
 
+    /// this function checks to see if we need to release resources if there are no active callbacks anymore
     let check (x : MultiCallbackObject) =
-        if cbs.Value.Count = 0 && not (isNull (obj :> obj)) then
-            obj.Outputs.Remove x |> ignore
-            if lock table (fun () -> table.Remove obj) then
-                level <- 0
-                obj <- Unchecked.defaultof<_>
-                weak <- null
-                false
-            else
-                true
+        // we don't need a lock here because we are using obj being null to indicate this is a dead object
+        if isNull (obj :> obj) then false
         else
-            true
+            // we must take a table lock here to prevent us from
+            // deciding to release this object before setMultiCallback can fetch this instance for a callback
+            // the Count must be checked after the lock since we need to be sure no one is add a subscription
+            // while we are in here.
+            lock table (fun _ ->                 
+                #if !FABLE_COMPILER
+                if cbs.Count = 0 then // since there are not more live callbacks we'd like to release this object
+                #else
+                if cbs.Value.Count = 0 then
+                #endif
+                    obj.Outputs.Remove x |> ignore
+                    table.Remove obj |> ignore  // it doesn't matter if the table has an entry for us or not
+                                                // if table didn't have a value then we need to clean up and make sure
+                                                // we return false because we're dead to the rest of the system, it if returns
+                                                // true then we've removed ourselve and we are dead to the system so clean ourselves
+                                                // up
+                    level <- 0
+                    obj <- Unchecked.defaultof<_>
+                    weak <- null
+                    false
+                else
+                    true
+            )
 
     let remove (x : MultiCallbackObject) (id : int) =
         lock x (fun () ->
+        #if !FABLE_COMPILER
+            cbs.TryRemove id |> ignore // attempt to remove the callback id
+        #else
             cbs.Value <- HashMap.remove id cbs.Value
+        #endif
             check x |> ignore
         )
 
@@ -72,13 +101,28 @@ type internal MultiCallbackObject(table : ConditionalWeakTable<IAdaptiveObject, 
     /// should automatically re-subscribe after being fired.
     member x.Subscribe(weak : bool, cb : unit -> bool) =
         lock x (fun () ->
-
+            assert ((obj :> obj) <> null)   // we assert that obj is not null, since the locks taken by check and setMultiCallback should prevent
+                                            // our getting to this point with an dead instance (obj is null). In debug mode we would see this
+                                            // fire an assertion failure
+            #if !FABLE_COMPILER
+            if cbs.Count = 0 then
+            #else
             if cbs.Value.Count = 0 then
+            #endif
                 obj.Outputs.Add x |> ignore
                 
             let id = newId()
             let weakCallback = WeakReference<_>(cb)
+            #if !FABLE_COMPILER
+            let success = cbs.TryAdd(id,weakCallback)
+            assert success                        // we assert success (this gets compiled out) here since by construction the lock on x
+                                                  // here and the increment of newId guarentee a new value of id until it wraps after
+                                                  // 4 billing subscriptions if that were to happen and the old subscriptions are still
+                                                  // around then new callbacks would simply be dropped on the ground for those id already
+                                                  // in the map.
+            #else
             cbs.Value <- HashMap.add id weakCallback cbs.Value
+            #endif
 
             #if !FABLE_COMPILER
             let remove() = remove x id
@@ -88,10 +132,27 @@ type internal MultiCallbackObject(table : ConditionalWeakTable<IAdaptiveObject, 
                 member __.Dispose() = remove x id
             }
             #endif
-
         )
     
     member x.Mark() =
+        #if !FABLE_COMPILE
+        // this loop allows us to move through the callbacks even if more are being added
+        // we check each callback to see if it is still alive and then if we are to retain
+        // it after executing
+        for (KeyValue(k,cb)) in cbs do // using a for loop here to indicate we doing some mutable code here
+                         // since this is usually considered a code smell in F# this indicates
+                         // that you should pay attention here. Please see the note where cbs
+                         // is declared regarding the behavior an enumerator on the 
+                         // ConcurrentDictionary
+            let filter =
+                match cb.TryGetTarget() with
+                | (true, cb) -> cb()
+                | _ -> false
+            if not filter then
+                // remove this entry
+                let success,_ = cbs.TryRemove(k) 
+                assert success // we assert that we successfully removed the entry, this shouldn't normally fail
+        #else
         cbs.Value <- 
             cbs.Value |> HashMap.filter (fun _ cb -> 
                 try 
@@ -101,6 +162,7 @@ type internal MultiCallbackObject(table : ConditionalWeakTable<IAdaptiveObject, 
                 with _ ->
                     false
             )
+        #endif
         if check x then
             obj.Outputs.Add x |> ignore
 
@@ -138,14 +200,16 @@ module CallbackExtensions =
     let private callbackObjects = ConditionalWeakTable<IAdaptiveObject, MultiCallbackObject>()
 
     /// utility getting/creating a MultiCallbackObjects for the given IAdaptiveObject  
-    let private getMultiCallback (o : IAdaptiveObject) =    
+    let private setMultiCallback (o : IAdaptiveObject) weak callback =    
         lock callbackObjects (fun () ->
-            match callbackObjects.TryGetValue o with
-            | (true, cbo) -> cbo
-            | _ -> 
-                let cbo = MultiCallbackObject(callbackObjects, o)
-                callbackObjects.Add(o, cbo)
-                cbo
+            let cbo =
+                match callbackObjects.TryGetValue o with
+                | (true, cbo) -> cbo
+                | _ -> 
+                    let cbo = MultiCallbackObject(callbackObjects, o)
+                    callbackObjects.Add(o, cbo)
+                    cbo
+            cbo.Subscribe(weak,callback)
         )
 
 
@@ -156,32 +220,28 @@ module CallbackExtensions =
         /// Note that it does not trigger when the object is currently out-of-date.
         /// Returns a disposable for removing the callback.
         member internal x.AddMarkingCallback (weak : bool, callback: unit -> unit) =
-            let cbo = getMultiCallback x
-            cbo.Subscribe(weak, fun () -> callback(); true)
+            setMultiCallback x weak (fun () -> callback(); true)
             
         /// Registers a callback with the given object that will be executed
         /// whenever the object gets marked out-of-date.
         /// Note that it does not trigger when the object is currently out-of-date.
         /// Returns a disposable for removing the callback.
         member x.AddMarkingCallback (callback: unit -> unit) =
-            let cbo = getMultiCallback x
-            cbo.Subscribe(false, fun () -> callback(); true)
+            setMultiCallback x false (fun () -> callback(); true)
             
         /// Registers a callback with the given object that will be executed
         /// whenever the object gets marked out-of-date.
         /// Note that it does not trigger when the object is currently out-of-date.
         /// Returns a disposable for removing the callback.
         member x.AddWeakMarkingCallback (callback: unit -> unit) =
-            let cbo = getMultiCallback x
-            cbo.Subscribe(true, fun () -> callback(); true)
+            setMultiCallback x true (fun () -> callback(); true)
 
         /// Registers a callback with the given object that will be executed
         /// ONCE! when the next out-of-date marking visits the object.
         /// Note that it does not trigger when the object is currently out-of-date.
         /// Returns a disposable for removing the callback.
         member x.OnNextMarking (callback: unit -> unit) =
-            let cbo = getMultiCallback x
-            cbo.Subscribe(false, fun () -> 
+            setMultiCallback x false (fun () -> 
                 try 
                     callback()
                     false
@@ -194,8 +254,7 @@ module CallbackExtensions =
         /// Note that it does not trigger when the object is currently out-of-date.
         /// Returns a disposable for removing the callback.
         member x.OnWeakNextMarking (callback: unit -> unit) =
-            let cbo = getMultiCallback x
-            cbo.Subscribe(true, fun () -> 
+            setMultiCallback x true (fun () -> 
                 try 
                     callback()
                     false


### PR DESCRIPTION
This change addresses issue #112 _NullPointerException in MultiCallbackObject when Mark is called by two thread and all the weak references have been garbage collected_.

I modified the implementation of the MultiCallbackObject type and the CallbackExtensions module to addresses the following problems:

- The let bound function check has been modified to check if the obj field is null first and immediately return false since this is a dead object now. The table lock is taken prior to the cbs.Count check for zero so that setMultiCallback can't get an instance that is about to kill itself. Prior to that change the decision to kill the object was made before the lock which would allow this instance to be return and a subscription could attempt to be added even though we then removed it.
- Changed the use of a ref<HashMap<_,_>> field to use an instance of ConcurrentDictionary so that a race condition on the assignment to cbs.Value in Mark and Subscribe was removed. The use of a ref value assignment could cause either a callback to not be registered or a fire once callback to be called twice. Now the add/remove operations are thread safe. ConcurrentDictionary has the following property that new keys that are ordered after the current key will be seen and keys less than the current value will not.
- Added a couple of assertions to throw when in debug mode for cases that shouldn't happen due to the locks taken and for TryRemove calls that should succeed. I made them assertions since they shouldn't cause correctness issues, its more to the point that somehow the key was already removed.
- Used a **_for loop_** construct to specifically call out the mutable nature of the Mark filtering of callbacks. I believe this will assist maintainers in understanding that this code IS NOT immutable, and care should be taken in thinking about the code paths involved.
- Changed getMultiCallback to setMultiCallback. This was to allow the Subscribe to take place within the table lock that should be taken to ensure a valid object is being accessed. Prior to this getMultiCallback could return an instance after taking the table lock and before calling Subscribe, another thread might be processing Mark which would then cause check to clear it which would then blow up or invalidate the Subscribe call. Subscribe is a FAST function so there is no reason not to take the lock on the table and complete it within that lock.

The use of a mutable data structure here is justified, I think due to the fact that MultiCallbackObject is not immutable itself, the need for thread safety. This of course could be implemented using the ref<HashMap> by taking a lock on the instance or cbs before assigning the value.

Thanks,
-Patrick